### PR TITLE
Add payment command skeleton

### DIFF
--- a/src/main/java/seedu/address/logic/commands/PaymentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PaymentCommand.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Displays a person's payment status using it's displayed index from the address book.
+ */
+public class PaymentCommand extends Command {
+
+    public static final String COMMAND_WORD = "payment";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Display payment status of person. "
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_PAYMENT_STATUS_SUCCESS = """
+            Name: %1$s
+            Payment status: %2$b
+            """;
+
+    private final Index targetIndex;
+
+    public PaymentCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToCheck = lastShownList.get(targetIndex.getZeroBased());
+        return new CommandResult(String.format(MESSAGE_PAYMENT_STATUS_SUCCESS,
+                personToCheck.getName(), personToCheck.getPaymentStatus()));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,15 +8,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,6 +68,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case PaymentCommand.COMMAND_WORD:
+            return new PaymentCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/PaymentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/PaymentCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.PaymentCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new PaymentCommand object
+ */
+public class PaymentCommandParser implements Parser<PaymentCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the PaymentCommand
+     * and returns an PaymentCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public PaymentCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new PaymentCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PaymentCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -114,4 +114,13 @@ public class Person {
                 .toString();
     }
 
+    /**
+     * Returns payment status of person. [Default = false]
+     * ModelManager currently creates List of contacts using Person class
+     * so temporarily added payment status method here so that payment command would work
+     * Method would be moved to Student class in future
+     */
+    public boolean getPaymentStatus() {
+        return false;
+    }
 }


### PR DESCRIPTION
Add the ```payment {index_number}``` command to the address book.

All contacts will currently display ```false``` for payment status.

Currently payment command is only able to display the payment status.

---

Notes:

The ```getPaymentStatus()``` method has been temporarily added to the Person class so that the payment command will work.

As per the method comment, this is a temporary implementation and the method will be moved to the ```Student``` class.