### PR TITLE
Fix merge conflict duplication for lessonLabel field

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -44,8 +44,7 @@ public class PersonCard extends UiPart<Region> {
     private Label email;
     @FXML
     private FlowPane tags;
-    @FXML
-    private Label lessonLabel;
+
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.


### PR DESCRIPTION
During the previous merge, the lessonLabel field was accidentally duplicated due to an incorrect conflict resolution. This PR removes the redundant field declaration to maintain code consistency and prevent compilation issues.

Changes made:

Removed duplicate Label lessonLabel declaration

Verified that only one valid field remains in the class

Confirmed that all existing references compile and function correctly